### PR TITLE
Mejora al componente card y añadida pagina con el menu de navegacion entre las distintas funciones que tendremos

### DIFF
--- a/src/front/components/DetailedCard.jsx
+++ b/src/front/components/DetailedCard.jsx
@@ -1,6 +1,6 @@
 export const DetailedCard = ({ product }) => {
     <div className="card">
-        <img src={roduct.image_url} className="card-img-top"></img>
+        <img src={product.image_url} className="card-img-top"></img>
         <div className="card-body">
             <h5>{product.name}</h5>
             <p>{product.category}</p>

--- a/src/front/components/DetailedCard.jsx
+++ b/src/front/components/DetailedCard.jsx
@@ -1,11 +1,11 @@
-export const DetailedCard = ({ imageProduct, name, price, quantity, category }) => {
+export const DetailedCard = ({ Product }) => {
     <div className="card">
-        <img src={imageProduct} className="card-img-top"></img>
+        <img src={Product.imageProduct} className="card-img-top"></img>
         <div className="card-body">
-            <h5>{name}</h5>
-            <p>{category}</p>
-            <p>{price}</p>
-            <p>{quantity}</p>
+            <h5>{Product.name}</h5>
+            <p>{Product.category}</p>
+            <p>{Product.price}</p>
+            <p>{Product.quantity}</p>
         </div>
     </div>
 }

--- a/src/front/components/DetailedCard.jsx
+++ b/src/front/components/DetailedCard.jsx
@@ -1,11 +1,11 @@
-export const DetailedCard = ({ Product }) => {
+export const DetailedCard = ({ product }) => {
     <div className="card">
-        <img src={Product.imageProduct} className="card-img-top"></img>
+        <img src={roduct.image_url} className="card-img-top"></img>
         <div className="card-body">
-            <h5>{Product.name}</h5>
-            <p>{Product.category}</p>
-            <p>{Product.price}</p>
-            <p>{Product.quantity}</p>
+            <h5>{product.name}</h5>
+            <p>{product.category}</p>
+            <p>{product.price}</p>
+            <p>{product.quantity}</p>
         </div>
     </div>
 }

--- a/src/front/components/Navigation.jsx
+++ b/src/front/components/Navigation.jsx
@@ -26,7 +26,7 @@ SingleTabPanel.propTypes = {
     value: PropTypes.number.isRequired,
 }
 
-function auxFunction(index) {
+function getTabsProps(index) {
     return {
         id: `simple-tab-${index}`,
         'aria-controls': `simple-tabpanel-${index}`,
@@ -44,10 +44,10 @@ const Navigation = () => {
         <>
             <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
                 <Tabs value={value} onChange={handleChange} variant="scrollable" scrollButtons="auto" aria-label="scrollable auto tabs">
-                    <Tab label="Feature Name" {...auxFunction(0)} />
-                    <Tab label="Feature Name" {...auxFunction(1)} />
-                    <Tab label="Feature Name" {...auxFunction(2)} />
-                    <Tab label="Feature Name" {...auxFunction(3)} />
+                    <Tab label="Feature Name" {...getTabsProps(0)} />
+                    <Tab label="Feature Name" {...getTabsProps(1)} />
+                    <Tab label="Feature Name" {...getTabsProps(2)} />
+                    <Tab label="Feature Name" {...getTabsProps(3)} />
                 </Tabs>
             </Box>
             <OnePanel value={value} index={0}>

--- a/src/front/components/Navigation.jsx
+++ b/src/front/components/Navigation.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Router, Link } from "react-router-dom";
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Box from '@mui/material/Box'
+import PropTypes from "prop-types";
+
+function OnePanel(props) {
+    const { children, value, index, ...other } = props; //el ...other es necesario para materialUI porque añade otros props sin necesidad de escribirlos
+
+    return (
+        <div
+            role="tabpanel"
+            hidden={value !== index}
+            id={`simple-tabpanel-${index}`}
+            aria-labelledby={`simple-tab-${index}`}
+            {...other}>
+            {value === index && <Box sx={{ p: 3 }}> {children}</Box>}
+        </div>
+    )
+}
+
+SingleTabPanel.propTypes = {
+    children: PropTypes.node,
+    index: PropTypes.number.isRequired,
+    value: PropTypes.number.isRequired,
+}
+
+function auxFunction(index) {
+    return {
+        id: `simple-tab-${index}`,
+        'aria-controls': `simple-tabpanel-${index}`,
+    }
+}
+
+const Navigation = () => {
+    const [value, setValue] = useState(0);
+
+    const handleChange = (event, newValue) => {
+        setValue(newValue);
+    }
+
+    return (
+        <>
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                <Tabs value={value} onChange={handleChange} variant="scrollable" scrollButtons="auto" aria-label="scrollable auto tabs">
+                    <Tab label="Feature Name" {...auxFunction(0)} />
+                    <Tab label="Feature Name" {...auxFunction(1)} />
+                    <Tab label="Feature Name" {...auxFunction(2)} />
+                    <Tab label="Feature Name" {...auxFunction(3)} />
+                </Tabs>
+            </Box>
+            <OnePanel value={value} index={0}>
+                Feature
+            </OnePanel>
+            <OnePanel value={value} index={1}>
+                Feature
+            </OnePanel>
+            <OnePanel value={value} index={2}>
+                Feature
+            </OnePanel>
+            <OnePanel value={value} index={3}>
+                Feature
+            </OnePanel>
+
+        </>
+    )
+}
+
+export default Navigation


### PR DESCRIPTION
Mejore el componente card para solo pasar como prop un objeto y de ahi ya usar los atributos del objeto en vez de tener que pasar cada atributo como props
Agregado el componente  donde esta el menu de navegacion para movernos entre las diferentes funciones que ofrecremos, solo habria que importar cada componente e incluirlo  como un nuevo "OnePanel" (realizado con materialUI)
